### PR TITLE
Upgrade dependencies

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,6 @@ dependencies:
   kiwi: ^0.1.0
 
 dev_dependencies:
-  test: ^1.0.0
-  build_runner: ^0.10.1
+  test: ^1.6.0
+  build_runner: ^1.3.1
   kiwi_generator: ^0.1.1

--- a/flutter_example/pubspec.yaml
+++ b/flutter_example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: '>=0.10.3 <1.2.0'
+  build_runner: '>=0.10.3 <1.4.0'
   kiwi_generator:
 
 # For information on the generic Dart part of this file, see the

--- a/kiwi/pubspec.yaml
+++ b/kiwi/pubspec.yaml
@@ -8,4 +8,4 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
-  test: ^1.0.0
+  test: ^1.6.0

--- a/kiwi_generator/pubspec.yaml
+++ b/kiwi_generator/pubspec.yaml
@@ -8,16 +8,16 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:  
-  analyzer: '>= 0.32.4 <0.35.0'
+  analyzer: '>= 0.32.4 <0.37.0'
   build: '>=0.12.6 <1.2.0'
   build_config: ^0.3.1
-  code_builder: ^3.1.3
+  code_builder: ^3.2.0
   dart_style: '>= 1.0.0 <1.3.0'
   kiwi: '>=0.1.0 <0.2.0'
   path: ^1.6.2
   source_gen: ^0.9.4
 
 dev_dependencies:
-  build_runner: ^1.1.0
-  build_test: ^0.10.3
-  test: ^1.0.0
+  build_runner: ^1.3.1
+  build_test: ^0.10.6
+  test: ^1.6.0

--- a/kiwi_generator/pubspec.yaml
+++ b/kiwi_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: '>= 0.32.4 <0.37.0'
   build: '>=0.12.6 <1.2.0'
   build_config: ^0.3.1
-  code_builder: ^3.2.0
+  code_builder: '>=3.1.3 <3.3.0'
   dart_style: '>= 1.0.0 <1.3.0'
   kiwi: '>=0.1.0 <0.2.0'
   path: ^1.6.2


### PR DESCRIPTION
I've upgraded the dependencies once again. These changes shouldn't affect users of this package because everything expect the `analyzer` and `code_builder` upgrades in `kiwi_generator` are just dev-dependency upgrades. 
### Code builder
The only change here is how the generated code looks, there is no API change: https://pub.dartlang.org/packages/code_builder#-changelog-tab-
### Analyzer
Shouldn't be a problem either. `0.36.0` is backwards-incompatible, but only when using APIs that operate on set-/map-literals. As `kiwi_generator` operates on the higher-level `elements` API only, this won't be a problem. https://pub.dartlang.org/packages/analyzer/versions/0.36.0#-changelog-tab-