### PR TITLE
Use cascade operators to call register methods

### DIFF
--- a/example/build.yaml
+++ b/example/build.yaml
@@ -1,4 +1,4 @@
-targets:
-  $default:
-    builders:
-      kiwi:
+#targets:
+#  $default:
+#    builders:
+#      kiwi:

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -1,4 +1,0 @@
-#targets:
-#  $default:
-#    builders:
-#      kiwi:

--- a/example/lib/src/modules/drip_coffee_module.g.dart
+++ b/example/lib/src/modules/drip_coffee_module.g.dart
@@ -10,12 +10,11 @@ class _$CoffeeInjector extends CoffeeInjector {
   @override
   void _configureFactories() {
     final KiwiContainer container = KiwiContainer();
-    container.registerFactory((c) => PowerOutlet());
-    container.registerSingleton((c) => Electricity(c<PowerOutlet>()));
     container
-        .registerSingleton<Heater>((c) => ElectricHeater(c<Electricity>()));
-    container.registerSingleton<Pump>((c) => Thermosiphon(c<Heater>()));
-    container.registerFactory(
-        (c) => CoffeeMaker(c<Heater>(), c<Pump>(), c<Model>()));
+      ..registerFactory((c) => PowerOutlet())
+      ..registerSingleton((c) => Electricity(c<PowerOutlet>()))
+      ..registerSingleton<Heater>((c) => ElectricHeater(c<Electricity>()))
+      ..registerSingleton<Pump>((c) => Thermosiphon(c<Heater>()))
+      ..registerFactory((c) => CoffeeMaker(c<Heater>(), c<Pump>(), c<Model>()));
   }
 }

--- a/flutter_example/build.yaml
+++ b/flutter_example/build.yaml
@@ -1,4 +1,4 @@
-targets:
-  $default:
-    builders:
-      kiwi:
+#targets:
+#  $default:
+#    builders:
+#      kiwi:

--- a/flutter_example/build.yaml
+++ b/flutter_example/build.yaml
@@ -1,4 +1,0 @@
-#targets:
-#  $default:
-#    builders:
-#      kiwi:

--- a/flutter_example/lib/di/test01.g.dart
+++ b/flutter_example/lib/di/test01.g.dart
@@ -10,8 +10,9 @@ class _$Injector extends Injector {
   @override
   void configure() {
     final KiwiContainer container = KiwiContainer();
-    container.registerFactory((c) => Test());
-    container.registerFactory((c) => Counter(c<Test>()));
-    container.registerSingleton((c) => Counter(c<Test>()), name: 'display');
+    container
+      ..registerFactory((c) => Test())
+      ..registerFactory((c) => Counter(c<Test>()))
+      ..registerSingleton((c) => Counter(c<Test>()), name: 'display');
   }
 }

--- a/kiwi_generator/README.md
+++ b/kiwi_generator/README.md
@@ -25,15 +25,6 @@ dev_dependencies:
   kiwi_generator: ^latest_version
 ```
 
-3. Add (or modify) the `build.yaml` file in the same folder as the `pubspec.yaml` and include the `kiwi` builder.
-
-```yaml
-targets:
-  $default:
-    builders:
-      kiwi:
-```
-
 ## Usage
 
 In your library add the following import:

--- a/kiwi_generator/test/kiwi_generator_test.dart
+++ b/kiwi_generator/test/kiwi_generator_test.dart
@@ -94,12 +94,13 @@ class _$Injector extends Injector {
   @override
   void configure() {
     final KiwiContainer container = KiwiContainer();
-    container.registerFactory((c) => ServiceA());
-    container.registerFactory((c) => ServiceB());
-    container.registerFactory((c) => ServiceB());
-    container.registerFactory<Service>((c) => ServiceB());
-    container.registerFactory((c) => ServiceA(), name: 'factoryA');
-    container.registerFactory<Service>((c) => ServiceB(), name: 'factoryB');
+    container
+      ..registerFactory((c) => ServiceA())
+      ..registerFactory((c) => ServiceB())
+      ..registerFactory((c) => ServiceB())
+      ..registerFactory<Service>((c) => ServiceB())
+      ..registerFactory((c) => ServiceA(), name: 'factoryA')
+      ..registerFactory<Service>((c) => ServiceB(), name: 'factoryB');
   }
 }
 ''';
@@ -109,12 +110,12 @@ class _$Injector extends Injector {
   @override
   void configure() {
     final KiwiContainer container = KiwiContainer();
-    container.registerFactory((c) => ServiceA());
-    container.registerFactory<Service>((c) => ServiceB(c<ServiceA>()));
-    container.registerFactory((c) => ServiceB(c<ServiceA>()), name: 'factoryB');
-    container.registerFactory(
-        (c) => ServiceC(c<ServiceA>(), c<ServiceB>('factoryB')));
-    container.registerFactory((c) => ServiceC.other(c<ServiceB>()));
+    container
+      ..registerFactory((c) => ServiceA())
+      ..registerFactory<Service>((c) => ServiceB(c<ServiceA>()))
+      ..registerFactory((c) => ServiceB(c<ServiceA>()), name: 'factoryB')
+      ..registerFactory((c) => ServiceC(c<ServiceA>(), c<ServiceB>('factoryB')))
+      ..registerFactory((c) => ServiceC.other(c<ServiceB>()));
   }
 }
 ''';
@@ -124,12 +125,12 @@ class _$Injector extends Injector {
   @override
   void configure() {
     final KiwiContainer container = KiwiContainer();
-    container.registerFactory((c) => ServiceA());
-    container.registerFactory<Service>((c) => ServiceB(c<ServiceA>()));
-    container.registerFactory((c) => ServiceB(c<ServiceA>()), name: 'factoryB');
-    container.registerFactory(
-        (c) => ServiceC(c<ServiceA>(), c<ServiceB>('factoryB')));
-    container.registerFactory((c) => ServiceC.other(c<ServiceB>()));
+    container
+      ..registerFactory((c) => ServiceA())
+      ..registerFactory<Service>((c) => ServiceB(c<ServiceA>()))
+      ..registerFactory((c) => ServiceB(c<ServiceA>()), name: 'factoryB')
+      ..registerFactory((c) => ServiceC(c<ServiceA>(), c<ServiceB>('factoryB')))
+      ..registerFactory((c) => ServiceC.other(c<ServiceB>()));
   }
 
   @override
@@ -142,12 +143,13 @@ class _$Injector extends Injector {
   @override
   void configure() {
     final KiwiContainer container = KiwiContainer();
-    container.registerSingleton((c) => ServiceA());
-    container.registerSingleton((c) => ServiceB());
-    container.registerSingleton((c) => ServiceB());
-    container.registerSingleton<Service>((c) => ServiceB());
-    container.registerSingleton((c) => ServiceA(), name: 'singletonA');
-    container.registerSingleton<Service>((c) => ServiceB(), name: 'singletonB');
+    container
+      ..registerSingleton((c) => ServiceA())
+      ..registerSingleton((c) => ServiceB())
+      ..registerSingleton((c) => ServiceB())
+      ..registerSingleton<Service>((c) => ServiceB())
+      ..registerSingleton((c) => ServiceA(), name: 'singletonA')
+      ..registerSingleton<Service>((c) => ServiceB(), name: 'singletonB');
   }
 }
 ''';
@@ -157,13 +159,13 @@ class _$Injector extends Injector {
   @override
   void configure() {
     final KiwiContainer container = KiwiContainer();
-    container.registerSingleton((c) => ServiceA());
-    container.registerSingleton<Service>((c) => ServiceB(c<ServiceA>()));
-    container.registerSingleton((c) => ServiceB(c<ServiceA>()),
-        name: 'factoryB');
-    container.registerSingleton(
-        (c) => ServiceC(c<ServiceA>(), c<ServiceB>('factoryB')));
-    container.registerSingleton((c) => ServiceC.other(c<ServiceB>()));
+    container
+      ..registerSingleton((c) => ServiceA())
+      ..registerSingleton<Service>((c) => ServiceB(c<ServiceA>()))
+      ..registerSingleton((c) => ServiceB(c<ServiceA>()), name: 'factoryB')
+      ..registerSingleton(
+          (c) => ServiceC(c<ServiceA>(), c<ServiceB>('factoryB')))
+      ..registerSingleton((c) => ServiceC.other(c<ServiceB>()));
   }
 }
 ''';


### PR DESCRIPTION
## Context

This PR address the issue that register methods are called on repeated `container` reference. According to Effective Dart's recommendation, repeated methods calls on the same target should be done using the cascade operator `..` on a single target reference. For example, instead of calling register methods like so:
```dart
final KiwiContainer container = KiwiContainer();
container.registerFactory();
container.registerSingleton();
```
it is cleaner to use the cascade operator on a single `container` reference:
```
container
  ..registerFactory()
  ..registerSingleton();
```

Closes #72 

## Approach

Instead of mapping annotations to repeated `Code` statements, the annotations are folded into a single cascade expression. For each annotation, a new expression is created by cascading on the previous expression.

---

By the way, `build.yaml` is giving me problems when running build_runner:
```
[INFO] Generating build script...
[INFO] Generating build script completed, took 318ms

[INFO] Precompiling build script......
[INFO] Precompiling build script... completed, took 4.7s

[SEVERE] Failed to parse `build.yaml` for flutter_example.

If you believe you have gotten this message in error, especially if using a new
feature, you may need to run `pub run build_runner clean` and then rebuild.

Invalid argument(s): line 4, column 7 of build.yaml: Unsupported value for "builders". type 'Null' is not a subtype of type 'Map<dynamic, dynamic>' in type cast
  ╷
4 │       kiwi:
  │       ^^^^^
  ╵
pub finished with exit code 78
```
The issue can be fixed by commenting out the content in `build.yaml`. Normally, a `build.yaml` is not required in a project that only consumes build runners such as `kiwi_generator`, so I think the step of adding a `build.yaml` to projects that use `kiwi` isn't necessary and should be removed.